### PR TITLE
INF-1276: bump actions/setup-go v5 -> v6.4.0 (Node 24)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum


### PR DESCRIPTION
Node 20 deprecation: forced Node-24 default 2026-06-02, Node 20 removed 2026-09-16.

`mathieudutour/github-tag-action@v6.2` (push.yaml:20) is also Node 20 but stuck — no Node-24 release available; tracked separately.