### PR TITLE
INF-1522: fix: sanitize path group header to prevent Prometheus label injection

### DIFF
--- a/add_path_group_header.go
+++ b/add_path_group_header.go
@@ -225,8 +225,31 @@ func extractPathGroup(path string) string {
 	return "/" + strings.Join(result, "/")
 }
 
+// maxLabelLen bounds the path-group value to limit metric-label cardinality and
+// abuse via long crafted paths.
+const maxLabelLen = 200
+
+// sanitizeLabel removes characters that are unsafe both in an HTTP header value and
+// in the Prometheus exposition format. Traefik exposes this header as a metric label
+// via metrics.prometheus.headerLabels, so an unsanitized request path containing a
+// newline, carriage return, double quote or backslash corrupts Traefik's /metrics
+// output and breaks the entire scrape. Control chars (< 0x20, which include CR/LF)
+// and DEL (0x7f) are dropped, and the result is bounded in length.
+func sanitizeLabel(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f || r == '"' || r == '\\' {
+			return -1
+		}
+		return r
+	}, s)
+	if runes := []rune(s); len(runes) > maxLabelLen {
+		s = string(runes[:maxLabelLen])
+	}
+	return s
+}
+
 func (a *AddPathHeader) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	pathGroup := extractPathGroup(req.URL.Path)
-	req.Header.Set(a.headerName, pathGroup)
+	req.Header.Set(a.headerName, sanitizeLabel(pathGroup))
 	a.next.ServeHTTP(rw, req)
 }

--- a/add_path_group_header_test.go
+++ b/add_path_group_header_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -392,4 +393,62 @@ func TestAddPathHeader_ExtractsPathGroup(t *testing.T) {
 			handler.ServeHTTP(rw, req)
 		})
 	}
+}
+
+func TestSanitizeLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean path unchanged", "/v1/courses/pending_actions", "/v1/courses/pending_actions"},
+		{"newline removed", "/v1/courses/pending_action\ninjected", "/v1/courses/pending_actioninjected"},
+		{"carriage return removed", "/v1/a\r/b", "/v1/a/b"},
+		{"double quote removed", "/v1/a\"b", "/v1/ab"},
+		{"backslash removed", "/v1/a\\b", "/v1/ab"},
+		{"tab and NUL removed", "/v1/a\tb\x00c", "/v1/abc"},
+		{"DEL removed", "/v1/a\x7fb", "/v1/ab"},
+		{"empty stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeLabel(tt.input); got != tt.want {
+				t.Errorf("sanitizeLabel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeLabel_BoundsLength(t *testing.T) {
+	got := sanitizeLabel("/" + strings.Repeat("a", 500))
+	if n := len([]rune(got)); n != maxLabelLen {
+		t.Errorf("expected length %d, got %d", maxLabelLen, n)
+	}
+}
+
+// TestAddPathHeader_SanitizesControlCharsInPath simulates a request whose decoded
+// URL path contains a newline (e.g. %0A in the request line, as seen during the
+// a2secure pentest). The header set for the Prometheus path_group label must not
+// contain any characters that would corrupt Traefik's /metrics exposition.
+func TestAddPathHeader_SanitizesControlCharsInPath(t *testing.T) {
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		got := req.Header.Get("x-path-group")
+		if strings.ContainsAny(got, "\n\r\"\\") {
+			t.Errorf("header contains unsafe characters: %q", got)
+		}
+		if got != "/v1/courses/pending_actioninjected" {
+			t.Errorf("unexpected sanitized header: %q", got)
+		}
+	})
+
+	handler, err := New(context.Background(), next, CreateConfig(), "test-middleware")
+	if err != nil {
+		t.Fatalf("unexpected error creating middleware: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/placeholder", nil)
+	req.URL.Path = "/v1/courses/pending_action\ninjected" // decoded form of a %0A-laden path
+	rw := httptest.NewRecorder()
+
+	handler.ServeHTTP(rw, req)
 }


### PR DESCRIPTION
## What
Sanitize the `X-Path-Group` header value before it is set, so the request path can never produce an invalid Prometheus exposition line.

## Why
`addPathGroupHeader` copied the URL-decoded request path verbatim into the `X-Path-Group` header, and Traefik exposes that header as the Prometheus `path_group` label via `metrics.prometheus.headerLabels`. A request whose path contained a newline (or `"` / `\` / other control char) produced a malformed `/metrics` line; the Datadog `traefik_mesh` OpenMetrics check then failed to parse it and **aborted the entire scrape**.

On 2026-06-30 this dropped **all `traefik-internal` metrics on develop (`dev-anemone-1`) from ~09:48 CEST**, while Traefik kept routing traffic normally. The trigger was an a2secure penetration test fuzzing `/v1/courses/pending_actions` with a control char in the path — effectively a metrics-injection vector via crafted request paths. The flaw is latent and predates the recent `3.7-plugins.3` image bump (plugin code unchanged since March), so an image rollback would not fix it.

Details & evidence: **INF-1522**.

## Change
- New `sanitizeLabel`: drops control chars (incl. CR/LF), `"`, `\` and DEL, and bounds the value length to 200; applied in `ServeHTTP` before `Header.Set`.
- Unit tests for the sanitizer (control chars, quote, backslash, length bound) and a middleware test simulating a `%0A`-laden path.

## Testing
- `go test ./...`, `go vet ./...`, `gofmt -l` — all clean; existing cases unaffected.

## Follow-ups (not in this PR)
- Rebuild the custom Traefik image → `traefik:3.7-plugins.4`, then bump `traefik_image_tag` in `terraform-aws-eks-cluster/k8s_ingress.tf` (develop → verify → pro).
- `api_host` (= `X-Forwarded-Host`) label is the same class of risk; consider hardening separately.
